### PR TITLE
Remove headbob when sprinting

### DIFF
--- a/Assets/prefabs/player/player.prefab
+++ b/Assets/prefabs/player/player.prefab
@@ -83,7 +83,7 @@
           "component_type": "Player"
         },
         "RespawnProtectionSaturation": 0.25,
-        "ShouldViewBob": true,
+        "ShouldViewBob": false,
         "ThirdPersonDistance": 128
       },
       {


### PR DESCRIPTION
Remove headbob when sprinting
Locate : player.prefab -> player -> Camera Controller -> Config -> Uncheck "Should View Bob"